### PR TITLE
Fix analyzer warning and potential crash

### DIFF
--- a/Source/JTSImageInfo.h
+++ b/Source/JTSImageInfo.h
@@ -20,7 +20,7 @@
 @property (strong, nonatomic) UIView *referenceView;
 @property (assign, nonatomic) UIViewContentMode referenceContentMode;
 @property (assign, nonatomic) CGFloat referenceCornerRadius;
-@property (copy, nonatomic) NSMutableDictionary *userInfo;
+@property (copy, nonatomic) NSDictionary *userInfo;
 
 - (NSString *)displayableTitleAltTextSummary;
 - (NSString *)combinedTitleAndAltText;

--- a/Source/JTSImageInfo.m
+++ b/Source/JTSImageInfo.m
@@ -35,10 +35,11 @@
     return text;
 }
 
-- (NSMutableDictionary *)userInfo {
+- (NSDictionary *)userInfo {
     if (_userInfo == nil) {
-        _userInfo = [[NSMutableDictionary alloc] init];
+        _userInfo = [[NSDictionary alloc] init];
     }
+
     return _userInfo;
 }
 


### PR DESCRIPTION
Warning was:

> JTSImageInfo.h:23:1: Property of mutable type 'NSMutableDictionary' has 'copy' attribute; an immutable object will be stored instead